### PR TITLE
Add global unwrapTuple func to easily remove tuples with optionals value

### DIFF
--- a/Source/Foundation/Protocols/OptionalType.swift
+++ b/Source/Foundation/Protocols/OptionalType.swift
@@ -17,13 +17,13 @@ public extension Sequence where Iterator.Element: OptionalType {
     /// Remove all the nullable values inside a nullable values array.
     ///
     /// - Returns: A Collection without null values.
-    var filterNil: [Iterator.Element.Wrapped] {
+    var filterNils: [Iterator.Element.Wrapped] {
         return compactMap { $0.wrapped }
     }
 
-    @available(*, deprecated, renamed: "filterNil")
-    var filterNils: [Iterator.Element.Wrapped] {
-        return filterNil
+    @available(*, deprecated, renamed: "filterNils")
+    var filterNil: [Iterator.Element.Wrapped] {
+        return filterNils
     }
 }
 

--- a/Source/Foundation/Protocols/OptionalType.swift
+++ b/Source/Foundation/Protocols/OptionalType.swift
@@ -17,7 +17,47 @@ public extension Sequence where Iterator.Element: OptionalType {
     /// Remove all the nullable values inside a nullable values array.
     ///
     /// - Returns: A Collection without null values.
+    var filterNil: [Iterator.Element.Wrapped] {
+        return compactMap { $0.wrapped }
+    }
+
+    @available(*, deprecated, renamed: "filterNil")
     var filterNils: [Iterator.Element.Wrapped] {
-        return self.compactMap { $0.wrapped }
+        return filterNil
+    }
+}
+
+/// Return nil if any of his components is nil
+public func unwrapTuple<A, B>(first: A?, second: B?) -> (A, B)? {
+    return first.flatMap { firstUnwrapped -> (A, B)? in
+        second.flatMap { secondUnwrapped -> (A, B)? in
+            return (firstUnwrapped, secondUnwrapped)
+        }
+    }
+}
+
+/// Return nil if any of his components is nil
+// swiftlint:disable large_tuple
+public func unwrapTuple<A, B, C>(first: A?, second: B?, third: C?) -> (A, B, C)? {
+    return first.flatMap { firstUnwraped -> (A, B, C)? in
+        second.flatMap { secondUnwrapped -> (A, B, C)? in
+            third.flatMap { thirdUnwrapped -> (A, B, C)? in
+                return (firstUnwraped, secondUnwrapped, thirdUnwrapped)
+            }
+        }
+    }
+}
+
+/// Return nil if any of his components is nil
+// swiftlint:disable large_tuple
+public func unwrapTuple<A, B, C, D>(first: A?, second: B?, third: C?, fourth: D?) -> (A, B, C, D)? {
+    return first.flatMap { firstUnwraped -> (A, B, C, D)? in
+        second.flatMap { secondUnwrapped -> (A, B, C, D)? in
+            third.flatMap { thirdUnwrapped -> (A, B, C, D)? in
+                fourth.flatMap { fourthUnwrapped -> (A, B, C, D)? in
+                    return (firstUnwraped, secondUnwrapped, thirdUnwrapped, fourthUnwrapped)
+                }
+            }
+        }
     }
 }

--- a/Tests/Foundation/Protocols/OptionalTypeTests.swift
+++ b/Tests/Foundation/Protocols/OptionalTypeTests.swift
@@ -16,4 +16,43 @@ class OptionalTypeTests: XCTestCase {
 
         XCTAssertEqual(array.filterNils, ["uno", "dos"])
     }
+
+    func test_uwrapTuple_of_2_elements() {
+        let tuple1 = (nil, "no") as (String?, String)
+        let tuple2 = ("hola", "chau")
+        let tuples = [tuple1, tuple2]
+
+        let result = tuples.compactMap(unwrapTuple)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.0, tuple2.0)
+        XCTAssertEqual(result.first?.1, tuple2.1)
+    }
+
+    func test_uwrapTuple_of_3_elements() {
+        let tuple1 = (nil, "mi", "bloste") as (String?, String, String)
+        let tuple2 = ("hola", "chau", "avión")
+        let tuples = [tuple1, tuple2]
+
+        let result = tuples.compactMap(unwrapTuple)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.0, tuple2.0)
+        XCTAssertEqual(result.first?.1, tuple2.1)
+        XCTAssertEqual(result.first?.2, tuple2.2)
+    }
+
+    func test_uwrapTuple_of_4_elements() {
+        let tuple1 = (nil, "mi", "bloste", nil) as (String?, String, String, Int?)
+        let tuple2 = ("hola", "chau", "avión", 5)
+        let tuples = [tuple1, tuple2]
+
+        let result = tuples.compactMap(unwrapTuple)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.0, tuple2.0)
+        XCTAssertEqual(result.first?.1, tuple2.1)
+        XCTAssertEqual(result.first?.2, tuple2.2)
+        XCTAssertEqual(result.first?.3, tuple2.3)
+    }
 }


### PR DESCRIPTION
### PR's key points
Add global unwrapTuple func to easily remove tuples with optionals value