### PR TITLE
Prepare Date.Format to handle an array of alternatives

### DIFF
--- a/MasMagicPills.xcodeproj/project.pbxproj
+++ b/MasMagicPills.xcodeproj/project.pbxproj
@@ -220,6 +220,10 @@
 		F258CE9C25F2A603007EF07E /* MagicError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F258CE9A25F2A603007EF07E /* MagicError.swift */; };
 		F258CE9D25F2A603007EF07E /* MagicError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F258CE9A25F2A603007EF07E /* MagicError.swift */; };
 		F258CE9E25F2A603007EF07E /* MagicError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F258CE9A25F2A603007EF07E /* MagicError.swift */; };
+		F25EED6528D0AB9400819C10 /* DateExtensions+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */; };
+		F25EED6628D0AB9400819C10 /* DateExtensions+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */; };
+		F25EED6728D0AB9400819C10 /* DateExtensions+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */; };
+		F25EED6828D0AB9400819C10 /* DateExtensions+Format.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */; };
 		F26C3AF822537A4600189D28 /* MagicPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* MagicPills.swift */; };
 		F26C3AF922537A4600189D28 /* MagicPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* MagicPills.swift */; };
 		F26C3AFA22537A4600189D28 /* MagicPills.swift in Sources */ = {isa = PBXBuildFile; fileRef = F26C3AF722537A4600189D28 /* MagicPills.swift */; };
@@ -469,6 +473,7 @@
 		F2496745230EBE4200C06E2E /* LastExecutionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastExecutionStateTests.swift; sourceTree = "<group>"; };
 		F2496749230EBE9500C06E2E /* JSONTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONTestHelper.swift; sourceTree = "<group>"; };
 		F258CE9A25F2A603007EF07E /* MagicError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagicError.swift; sourceTree = "<group>"; };
+		F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateExtensions+Format.swift"; sourceTree = "<group>"; };
 		F26C3AF722537A4600189D28 /* MagicPills.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagicPills.swift; sourceTree = "<group>"; };
 		F26C630426C422160065E04C /* CodableTestObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableTestObject.swift; sourceTree = "<group>"; };
 		F27512AB252B3DCB0057D6F0 /* CollectionCellForTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionCellForTests.swift; sourceTree = "<group>"; };
@@ -886,6 +891,7 @@
 				F297F0C824E55B0A00963BD8 /* CollectionExtensions.swift */,
 				F2008329225F862900AC6EE1 /* DataExtensions.swift */,
 				F20082E4225E1E0000AC6EE1 /* DateExtensions.swift */,
+				F25EED6428D0AB9400819C10 /* DateExtensions+Format.swift */,
 				F20082F2225E518600AC6EE1 /* DecimalExtensions.swift */,
 				F22A38E6227C76FD0012C010 /* DictionaryExtensions.swift */,
 				F22A356B228077E8004E8546 /* DispatchQueueExtensions.swift */,
@@ -1377,6 +1383,7 @@
 				F62CC32722704F0500DC46F2 /* UIStackViewExtensions.swift in Sources */,
 				F2C78F1C238D679C008C4846 /* UICollectionReusableViewExtensions.swift in Sources */,
 				F6D6D4CA230D5CBD00D161F9 /* TimeZoneExtensions.swift in Sources */,
+				F25EED6528D0AB9400819C10 /* DateExtensions+Format.swift in Sources */,
 				F20082F3225E518600AC6EE1 /* DecimalExtensions.swift in Sources */,
 				F2496739230EB99400C06E2E /* ZoomAndSnapFlowLayout.swift in Sources */,
 				F2C1A26024E2E055005DC7A8 /* StringExtensions+Crypto.swift in Sources */,
@@ -1490,6 +1497,7 @@
 				F26C3AF922537A4600189D28 /* MagicPills.swift in Sources */,
 				F2C1A28024E45EFD005DC7A8 /* Int64Extensions.swift in Sources */,
 				F6F3330E23042AEA00E93F0E /* CALayerExtensions.swift in Sources */,
+				F25EED6628D0AB9400819C10 /* DateExtensions+Format.swift in Sources */,
 				F2091DB12631AD23002F071E /* CodableExtensions.swift in Sources */,
 				F2E4801126B83FB90055A0D6 /* TextStyleModifier.swift in Sources */,
 				F2C1A27924E41E76005DC7A8 /* NSAttributedStringExtensions.swift in Sources */,
@@ -1596,6 +1604,7 @@
 				F2A74DBB225765CF001F0DF2 /* ArrayExtensions.swift in Sources */,
 				F2C78F1D238D679C008C4846 /* UICollectionReusableViewExtensions.swift in Sources */,
 				F6D6D4CC230D5CBD00D161F9 /* TimeZoneExtensions.swift in Sources */,
+				F25EED6728D0AB9400819C10 /* DateExtensions+Format.swift in Sources */,
 				F62CC32822704F0500DC46F2 /* UIStackViewExtensions.swift in Sources */,
 				F249673C230EBB7A00C06E2E /* ZoomAndSnapFlowLayout.swift in Sources */,
 				F2C1A26224E2E07A005DC7A8 /* StringExtensions+Crypto.swift in Sources */,
@@ -1730,6 +1739,7 @@
 				F2496744230EBDEF00C06E2E /* LastExecutionState.swift in Sources */,
 				F22A356522807465004E8546 /* Fold.swift in Sources */,
 				F20082E8225E1E0000AC6EE1 /* DateExtensions.swift in Sources */,
+				F25EED6828D0AB9400819C10 /* DateExtensions+Format.swift in Sources */,
 				F22A355F22806EAD004E8546 /* DefinesPrimaryKey.swift in Sources */,
 				F297F0CC24E55B1100963BD8 /* CollectionExtensions.swift in Sources */,
 				F2C1A27B24E41E77005DC7A8 /* NSAttributedStringExtensions.swift in Sources */,

--- a/Source/Foundation/Extensions/DateExtensions+Format.swift
+++ b/Source/Foundation/Extensions/DateExtensions+Format.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+public extension Date {
+    /// Specify date format to convert
+    ///
+    /// - iso8601: 2019-08-09T12:48:00.000+0200
+    /// - rfc1123: Fri, 09 Aug 2019 12:48:00 GMT+2
+    /// - spanishFullDateWithSlashes: 09/08/2019 12:48
+    /// - americanFullDateWithSlashes: 08/09/2019 12:48
+    /// - europeanFullDateWithSlashes: 2019/08/09 12:48
+    /// - europeanDateWithDashes: 2019-08-09
+    /// - time: 12:48
+    /// - day: 9
+    /// - shortMonth: aug
+    /// - month: august
+    /// - monthAndYear: august 2019
+    /// - monthAndYearWithUnderscore: august_2019
+    /// - shortYear: 19
+    /// - year: 2019
+    /// - spanishDayAndMonth: 09 de agosto
+    enum Format: String, CaseIterable {
+        case iso8601 = "yyyy-MM-dd'T'HH:mm:ssZ"
+        case rfc1123 = "EEE, dd MMM yyyy HH:mm:ss z"
+        case spanishDateWithSlashes = "dd/MM/yyyy"
+        case spanishDayAndMonthWithSlashes = "dd/MM"
+        case spanishFullDateWithSlashes = "dd/MM/yyyy HH:mm"
+        case americanFullDateWithSlashes = "MM/dd/yyyy HH:mm"
+        case europeanFullDateWithSlashes = "yyyy/MM/dd HH:mm"
+        case europeanDateWithDashes = "yyyy-MM-dd"
+        case time = "HH:mm"
+        case day = "d"
+        case shortMonth = "MMM"
+        case month = "MMMM"
+        case monthAndYear = "MMMM yyyy"
+        case monthAndYearWithUnderscore = "MMMM_yyyy"
+        case shortYear = "yy"
+        case year = "yyyy"
+        case yearAndMonth = "yyyy-MM"
+        case spanishDayAndMonth = "dd 'de' MMMM"
+        case dateStyleShort = "dateStyleShort"
+        case dateStyleMedium = "dateStyleMedium"
+        case dateStyleLong = "dateStyleLong"
+        case dateStyleFull = "dateStyleFull"
+
+        func date(formattedDate: String, locale: Locale?, timeZone: TimeZone?) -> Date? {
+            let dateFormatter = formatter(locale: locale, timeZone: timeZone)
+
+            var date: Date?
+            if let dateFormats = dateFormats(timeZone: timeZone) {
+                for dateFormat in dateFormats {
+                    dateFormatter.dateFormat = dateFormat
+                    date = dateFormatter.date(from: formattedDate)
+                    if date != nil { break }
+                }
+            }
+
+            return date
+        }
+
+        func dateFormats(timeZone: TimeZone?) -> [String]? {
+            guard let mainDateFormat = mainDateFormat(timeZone: timeZone) else {
+                return nil
+            }
+
+            switch self {
+            case .iso8601:
+                return [mainDateFormat,
+                        "yyyy-MM-dd'T'HH:mmZ",
+                        "yyyy-MM-dd'T'HH:mm:ss.SSSZ"]
+
+            case .rfc1123:
+                return [mainDateFormat,
+                        "EEE, dd MMM yyyy HH:mm:ss Z"]
+
+            default:
+                return [mainDateFormat]
+            }
+        }
+
+        func mainDateFormat(timeZone: TimeZone?) -> String? {
+            switch self {
+            // For ISO8601 dates, if the timezone is UTC, use Z instead of +0000
+            case .iso8601 where timeZone == .utc:
+                return rawValue.replacingOccurrences(of: "Z", with: "'Z'")
+
+            case .dateStyleShort:
+                return nil
+
+            case .dateStyleMedium:
+                return nil
+
+            case .dateStyleLong:
+                return nil
+
+            case .dateStyleFull:
+                return nil
+
+            default:
+                return rawValue
+            }
+        }
+
+        func formatter(locale: Locale?, timeZone: TimeZone?) -> DateFormatter {
+            let dateFormatter = Formatter.date(locale: locale, timeZone: timeZone)
+
+            switch self {
+            case .dateStyleShort:
+                dateFormatter.dateStyle = .short
+
+            case .dateStyleMedium:
+                dateFormatter.dateStyle = .medium
+
+            case .dateStyleLong:
+                dateFormatter.dateStyle = .long
+
+            case .dateStyleFull:
+                dateFormatter.dateStyle = .full
+
+            default:
+                dateFormatter.dateFormat = mainDateFormat(timeZone: timeZone)
+            }
+            return dateFormatter
+        }
+    }
+}

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -20,7 +20,7 @@ class DateExtensionsTests: XCTestCase {
 
     func test_init_from_formatted_dates() {
         let rfcDate = Date(formattedDate: "2019-08-09T12:48:00.000+0200",
-                           dateFormat: .rfc3339)
+                           dateFormat: .iso8601)
         XCTAssertEqual(rfcDate?.formatted(with: .iso8601, timeZone: .utc), "2019-08-09T10:48:00Z")
 
         let iso8601DateUTC = Date(formattedDate: "2020-02-10T17:26:08Z",
@@ -43,11 +43,6 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(spanishDate?.formatted(with: .iso8601, timeZone: .utc), "2018-02-20T11:33:00Z")
     }
 
-    func test_init_from_formatted_dates_with_try() {
-        XCTAssertNoThrow(try Date(tryFormattedDate: "2019-08-09T12:48:00.000+0200", dateFormat: .rfc3339))
-        XCTAssertThrowsError(try Date(tryFormattedDate: "2019-08-09T12:48:00.000+0200", dateFormat: .dateStyleMedium))
-    }
-
     func test_init_with_milliseconds() {
         let milliseconds: Double = 12_408_124_000
         let date = Date(millisecondsSince1970: milliseconds)
@@ -65,21 +60,31 @@ class DateExtensionsTests: XCTestCase {
                        rfc1123Date)
     }
 
-    func test_init_with_rfc3339date() {
-        let rfc3339Date = "2019-08-09T10:48:00.000+0200"
-        let date = rfc3339Date.date()
-        XCTAssertEqual(date?.formatted(with: .rfc3339,
+    func test_init_with_rfc1123date_with_offset() {
+        let rfc1123Date = "Fri, 09 Aug 2019 12:48:00 +0200"
+        let date = rfc1123Date.date(dateFormat: .rfc1123, locale: .posix, timeZone: .utc)
+
+        XCTAssertEqual(date?.formatted(with: .rfc1123,
+                                       locale: .posix,
+                                       timeZone: .utc),
+                       "Fri, 09 Aug 2019 10:48:00 GMT")
+    }
+
+    func test_init_with_iso8601date() {
+        let iso8601Date = "2019-08-09T10:48:00.000+0200"
+        let date = iso8601Date.date()
+        XCTAssertEqual(date?.formatted(with: .iso8601,
                                        timeZone: .europeMadrid),
-                       rfc3339Date)
+                       "2019-08-09T10:48:00+0200")
         XCTAssertNil("👋".date())
     }
 
-    func test_init_with_rfc3339date_with_no_seconds() { // "2021-04-07T09:00+01:00"
-        let rfc3339Date = "2021-04-07T09:00+0100"
-        let date = rfc3339Date.date()
-        XCTAssertEqual(date?.formatted(with: .rfc3339,
+    func test_init_with_iso8601date_with_no_seconds() { // "2021-04-07T09:00+01:00"
+        let iso8601Date = "2021-04-07T09:00+0100"
+        let date = iso8601Date.date()
+        XCTAssertEqual(date?.formatted(with: .iso8601,
                                        timeZone: .europeMadrid),
-                       "2021-04-07T10:00:00.000+0200")
+                       "2021-04-07T10:00:00+0200")
         XCTAssertNil("👋".date())
     }
 
@@ -114,8 +119,6 @@ class DateExtensionsTests: XCTestCase {
 
         XCTAssertEqual(date.formatted(with: .iso8601, timeZone: .utc), "2019-08-09T10:48:00Z")
         XCTAssertEqual(date.formatted(with: .iso8601, timeZone: .europeMadrid), "2019-08-09T12:48:00+0200")
-        XCTAssertEqual(date.formatted(with: .rfc3339, timeZone: .europeMadrid), "2019-08-09T12:48:00.000+0200")
-        XCTAssertEqual(date.formatted(with: .rfc2822, locale: .englishUSA, timeZone: .europeMadrid), "Fri, 09 Aug 2019 12:48:00 +0200")
         XCTAssertEqual(date.formatted(with: .rfc1123, locale: .englishUSA, timeZone: .europeMadrid), "Fri, 09 Aug 2019 12:48:00 GMT+2")
         XCTAssertEqual(date.formatted(with: .spanishDateWithSlashes, timeZone: .europeMadrid), "09/08/2019")
         XCTAssertEqual(date.formatted(with: .spanishDayAndMonthWithSlashes), "09/08")


### PR DESCRIPTION
### PR's key points
Extended Date.Format to try the parse action from string using alternatives for each case.
ISO8601 has many accepted formats. 
 
### How to review this PR?
(https://ijmacd.github.io/rfc3339-iso8601/)
