### PR TITLE
Use ISO8601DateFormatter as fallback if any our formats can’t parse

### DIFF
--- a/Source/Foundation/Extensions/DateExtensions.swift
+++ b/Source/Foundation/Extensions/DateExtensions.swift
@@ -12,13 +12,13 @@ public extension Date {
           dateFormat: Format? = nil,
           locale: Locale? = nil,
           timeZone: TimeZone? = nil) {
-        if let dateFormat = dateFormat, let date = dateFormat.date(formattedDate: formattedDate, locale: locale, timeZone: timeZone) {
+        if let dateFormat = dateFormat, let date = dateFormat.date(from: formattedDate, locale: locale, timeZone: timeZone) {
             self = date
             return
         }
 
         for dateFormat in Format.allCases {
-            if let date = dateFormat.date(formattedDate: formattedDate, locale: locale, timeZone: timeZone) {
+            if let date = dateFormat.date(from: formattedDate, locale: locale, timeZone: timeZone) {
                 self = date
                 return
             }
@@ -106,14 +106,7 @@ public extension Date {
     func formatted(with dateFormat: Date.Format,
                    locale: Locale? = nil,
                    timeZone: TimeZone? = nil) -> String {
-        let formatter = dateFormat.formatter(locale: locale,
-                                             timeZone: timeZone)
-
-        if let dateFormat = dateFormat.mainDateFormat(timeZone: timeZone) {
-            formatter.dateFormat = dateFormat
-        }
-
-        return formatter.string(from: self)
+        dateFormat.string(from: self, locale: locale, timeZone: timeZone)
     }
 
     /// Calculate months to end dates, included days in last month or not

--- a/Source/Foundation/Extensions/FormatterExtensions.swift
+++ b/Source/Foundation/Extensions/FormatterExtensions.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public extension Formatter {
     /// Get DateFormatter with specific Locale and TimeZone
     ///
@@ -9,6 +11,17 @@ public extension Formatter {
                      timeZone: TimeZone? = nil) -> DateFormatter {
         let dateFormatter = DateFormatter()
         if let locale = locale { dateFormatter.locale = locale }
+        if let timeZone = timeZone { dateFormatter.timeZone = timeZone }
+        return dateFormatter
+    }
+
+    /// Get ISO8601 DateFormatter with specific Locale and TimeZone
+    ///
+    /// - Parameters:
+    ///   - timeZone: Specific Time Zone to format (optional) (by default use current)
+    /// - Returns: ISO8601DateFormatter with specific or current Time Zone
+    static func iso8601Date(timeZone: TimeZone? = nil) -> ISO8601DateFormatter {
+        let dateFormatter = ISO8601DateFormatter()
         if let timeZone = timeZone { dateFormatter.timeZone = timeZone }
         return dateFormatter
     }

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -70,12 +70,21 @@ class DateExtensionsTests: XCTestCase {
                        "Fri, 09 Aug 2019 10:48:00 GMT")
     }
 
-    func test_init_with_iso8601date() {
+    func test_init_with_iso8601date_with_seconds_and_thousandths() {
         let iso8601Date = "2019-08-09T10:48:00.000+0200"
         let date = iso8601Date.date()
         XCTAssertEqual(date?.formatted(with: .iso8601,
                                        timeZone: .europeMadrid),
                        "2019-08-09T10:48:00+0200")
+        XCTAssertNil("👋".date())
+    }
+
+    func test_init_with_iso8601date_with_seconds() {
+        let iso8601Date = "2022-10-27T16:00:00+0200"
+        let date = iso8601Date.date(dateFormat: .iso8601)
+        XCTAssertEqual(date?.formatted(with: .iso8601,
+                                       timeZone: .europeMadrid),
+                       "2022-10-27T16:00:00+0200")
         XCTAssertNil("👋".date())
     }
 


### PR DESCRIPTION
### PR's key points
Check test, add `ISO8601DateFormatter` as fallback if any of other formats can't parse an `String` into `Date`
