### PR TITLE
Fix decimal round

### DIFF
--- a/Source/Foundation/Extensions/DecimalExtensions.swift
+++ b/Source/Foundation/Extensions/DecimalExtensions.swift
@@ -44,21 +44,17 @@ public extension Decimal {
 
     /// Return integer part
     var integerPart: Int {
-        var result = Decimal()
-        var mutableSelf = self
-        NSDecimalRound(&result, &mutableSelf, 0, self >= 0 ? .down : .up)
-        return Int(truncating: NSDecimalNumber(decimal: result))
+        (self as NSNumber).intValue
     }
 
     /// Return decimal part
     func decimalPart(decimals: Int) -> Int {
-        var result = Decimal()
-        let powered = pow(Decimal(10), decimals)
-        let integerPartToRemove = (powered * Decimal(abs(integerPart)))
-        var elevated = powered * abs(self)
+        let fractionalPart = self - Decimal((integerPart))
+        let multiplier = pow(10, decimals)
+        let scaledNumber = fractionalPart * multiplier
+        let truncatedNumber = Int(truncating: scaledNumber as NSNumber)
 
-        NSDecimalRound(&result, &elevated, 0, .down)
-        return Int(truncating: NSDecimalNumber(decimal: result - integerPartToRemove))
+        return abs(truncatedNumber)
     }
 
     /// Split the number into decimal and integer part

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -153,7 +153,7 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(date.formatted(with: .dateStyleMedium, locale: .spanishSpain, timeZone: .europeMadrid), "9 ago 2019")
         XCTAssertEqual(date.formatted(with: .dateStyleFull, locale: .spanishSpain, timeZone: .europeMadrid), "viernes, 9 de agosto de 2019")
         XCTAssertEqual(date.formatted(with: .dateStyleLong, locale: .spanishSpain, timeZone: .europeMadrid), "9 de agosto de 2019")
-        XCTAssertEqual(date.formatted(with: .dateStyleLong, locale: .catalanSpain, timeZone: .europeMadrid), "9 d’agost de 2019")
+        XCTAssertEqual(date.formatted(with: .dateStyleLong, locale: .catalanSpain, timeZone: .europeMadrid), "9 d’agost del 2019")
         XCTAssertTrue(date.formatted(with: .dateStyleLong, locale: .basqueSpain, timeZone: .europeMadrid).starts(with: "2019(e)ko abuztua"))
     }
 

--- a/Tests/Foundation/Extensions/DecimalExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DecimalExtensionsTests.swift
@@ -139,6 +139,22 @@ class DecimalExtensionsTests: XCTestCase {
         XCTAssertEqual(result.decimalPart, 697)
     }
 
+    func test_integer_part() {
+        XCTAssertEqual(Decimal(0).integerPart, 0)
+        XCTAssertEqual(Decimal(0.3).integerPart, 0)
+        XCTAssertEqual(Decimal(0.8).integerPart, 0)
+        XCTAssertEqual(Decimal(2.4).integerPart, 2)
+        XCTAssertEqual(Decimal(-3.8).integerPart, -3)
+    }
+
+    func test_decimal_part() {
+        XCTAssertEqual(Decimal(0).decimalPart(decimals: 0), 0)
+        XCTAssertEqual(Decimal(0.3).decimalPart(decimals: 1), 3)
+        XCTAssertEqual(Decimal(0.8).decimalPart(decimals: 2), 80)
+        XCTAssertEqual(Decimal(2.4).decimalPart(decimals: 0), 0)
+        XCTAssertEqual(Decimal(-3.8).decimalPart(decimals: 3), 800)
+    }
+
     func test_format_decimal_part() {
         XCTAssertEqual((5.532 as Decimal).formattedDecimalPart(decimals: 1, locale: .spanishSpain), ",5")
         XCTAssertEqual((-5.532 as Decimal).formattedDecimalPart(decimals: 2, locale: .spanishSpain), ",53")


### PR DESCRIPTION
### PR's key points
Due to a bug in Foundation/Xcode 16, running an app built against the iOS 18 SDK on a device running a version lower than iOS 18 causes a crash when using the `NSDecimal` APIs.

Según las release notes de Xcode 16 esto está corregido, pero no es verdad. Se puede ver más [aquí](https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#Foundation)