### PR TITLE
Remove unnecesary methods

### DIFF
--- a/Source/Foundation/Extensions/DateExtensions.swift
+++ b/Source/Foundation/Extensions/DateExtensions.swift
@@ -146,9 +146,4 @@ public extension Date {
         }
         return .morning
     }
-
-    /// Give the previous month name from current Date
-    static func previousMonthName(locale: Locale = .spanishSpain, timeZone: TimeZone = .europeMadrid) -> String {
-        Date().adding(months: -1).formatted(with: .month, locale: locale, timeZone: timeZone)
-    }
 }


### PR DESCRIPTION
### PR's key points
Remove previousMonthName method because it didn't work as we want. We have added the new method called localizedMonthName.

The difference is that with this method we don't have to pass a locale for language changing so if the app is in spanish the date is going to appear in spanish, and the same with any other languages.
 
### How to review this PR?
Check that the app compiles and the tests work correctly
