### PR TITLE
Add new method in date extensions

### DIFF
--- a/Source/Foundation/Extensions/DateExtensions+Format.swift
+++ b/Source/Foundation/Extensions/DateExtensions+Format.swift
@@ -25,7 +25,7 @@ public extension Date {
         case spanishDateWithSlashes = "dd/MM/yyyy"
         case americanDateWithSlashes = "MM/dd/yyyy"
         case spanishDayAndMonthWithSlashes = "dd/MM"
-        case spanishMonthAndYearWithSlashes = "MM/yyyy"
+        case spanishMonthAndYearWithSlashes = "MM/yy"
         case spanishFullDateWithSlashes = "dd/MM/yyyy HH:mm"
         case americanFullDateWithSlashes = "MM/dd/yyyy HH:mm"
         case europeanFullDateWithSlashes = "yyyy/MM/dd HH:mm"

--- a/Source/Foundation/Extensions/DateExtensions+Format.swift
+++ b/Source/Foundation/Extensions/DateExtensions+Format.swift
@@ -25,6 +25,7 @@ public extension Date {
         case spanishDateWithSlashes = "dd/MM/yyyy"
         case americanDateWithSlashes = "MM/dd/yyyy"
         case spanishDayAndMonthWithSlashes = "dd/MM"
+        case spanishMonthAndYearWithSlashes = "MM/yyyy"
         case spanishFullDateWithSlashes = "dd/MM/yyyy HH:mm"
         case americanFullDateWithSlashes = "MM/dd/yyyy HH:mm"
         case europeanFullDateWithSlashes = "yyyy/MM/dd HH:mm"

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -132,7 +132,7 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(date.formatted(with: .spanishDateWithSlashes, timeZone: .europeMadrid), "09/08/2019")
         XCTAssertEqual(date.formatted(with: .americanDateWithSlashes, timeZone: .europeMadrid), "08/09/2019")
         XCTAssertEqual(date.formatted(with: .spanishDayAndMonthWithSlashes), "09/08")
-        XCTAssertEqual(date.formatted(with: .spanishMonthAndYearWithSlashes), "08/2019")
+        XCTAssertEqual(date.formatted(with: .spanishMonthAndYearWithSlashes), "08/19")
         XCTAssertEqual(date.formatted(with: .spanishFullDateWithSlashes, timeZone: .europeMadrid), "09/08/2019 12:48")
         XCTAssertEqual(date.formatted(with: .americanFullDateWithSlashes, timeZone: .europeMadrid), "08/09/2019 12:48")
         XCTAssertEqual(date.formatted(with: .europeanFullDateWithSlashes, timeZone: .europeMadrid), "2019/08/09 12:48")

--- a/Tests/Foundation/Extensions/DateExtensionsTests.swift
+++ b/Tests/Foundation/Extensions/DateExtensionsTests.swift
@@ -132,6 +132,7 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(date.formatted(with: .spanishDateWithSlashes, timeZone: .europeMadrid), "09/08/2019")
         XCTAssertEqual(date.formatted(with: .americanDateWithSlashes, timeZone: .europeMadrid), "08/09/2019")
         XCTAssertEqual(date.formatted(with: .spanishDayAndMonthWithSlashes), "09/08")
+        XCTAssertEqual(date.formatted(with: .spanishMonthAndYearWithSlashes), "08/2019")
         XCTAssertEqual(date.formatted(with: .spanishFullDateWithSlashes, timeZone: .europeMadrid), "09/08/2019 12:48")
         XCTAssertEqual(date.formatted(with: .americanFullDateWithSlashes, timeZone: .europeMadrid), "08/09/2019 12:48")
         XCTAssertEqual(date.formatted(with: .europeanFullDateWithSlashes, timeZone: .europeMadrid), "2019/08/09 12:48")


### PR DESCRIPTION
### PR's key points
Add new method in Date extension. The main goal of the method is to get the next format: MM/yy
