### PR TITLE
feat: Update nif validator

### DIFF
--- a/Sources/Foundation/Extensions/StringExtensions+Validators.swift
+++ b/Sources/Foundation/Extensions/StringExtensions+Validators.swift
@@ -51,7 +51,7 @@ public extension String {
             .replacingOccurrences(of: "\\", with: "")
             .removingWhiteSpaces
 
-        if identifierBase.satisfiesRegex("^[0-9]{0,1}[0-9]{7}[TRWAGMYFPDXBNJZSQVHLCKET]{1}$") {
+        if identifierBase.satisfiesRegex("^[0-9]{8}[TRWAGMYFPDXBNJZSQVHLCKEtrwagmyfpdxbnjzsqvhlcke]$") {
             guard let numberBase = Int(identifierBase.prefix(identifierBase.count - 1)),
                   let letter: Character = identifierBase.last else {
                 return false

--- a/Tests/Foundation/Extensions/StringExtensions+ValidatorsTests.swift
+++ b/Tests/Foundation/Extensions/StringExtensions+ValidatorsTests.swift
@@ -64,9 +64,13 @@ class StringExtensionsValidatorsTests: XCTestCase {
         XCTAssertTrue("21234567R".isValidNIF)
         XCTAssertTrue("12345678Z".isValidNIF)
         XCTAssertTrue("05446767E".isValidNIF)
+        XCTAssertTrue("00353635X".isValidNIF)
     }
 
     func test_is_not_valid_nif() {
+        XCTAssertFalse("5446767E".isValidNIF)
+        XCTAssertFalse("353635X".isValidNIF)
+        XCTAssertFalse("0353635X".isValidNIF)
         XCTAssertFalse("05446767F".isValidNIF)
         XCTAssertFalse("kkk".isValidNIF)
         XCTAssertFalse("".isValidNIF)


### PR DESCRIPTION
### PR's key points
Actually our nif-Regex validates NIFs with 7 and 8 digits so we decide include 6-digits nifs too.
 
### How to review this PR?
Pass tests
